### PR TITLE
37 distance odd ness

### DIFF
--- a/codes/bacon_shor.py
+++ b/codes/bacon_shor.py
@@ -14,7 +14,7 @@ from gen import _gen_util
 
 from qiskit_qec.circuits import StimCodeCircuit
 
-def get_bacon_shot_code(d=5, cycles=1):
+def get_bacon_shor_code(d=5, cycles=1):
     #This custom value should be fixed because it seems there lies the problem
     #Workflow:
     #https://github.com/Strilanc/more-bacon-less-threshold/blob/main/step1_generate_circuits.sh
@@ -48,4 +48,4 @@ def get_bacon_shot_code(d=5, cycles=1):
 
 
 if __name__ == "__main__":
-    get_bacon_shot_code()
+    get_bacon_shor_code()

--- a/codes/utils.py
+++ b/codes/utils.py
@@ -52,18 +52,22 @@ def get_max_d(code_name: str, n: int):
             raise 1 #Note that a Error will be logged in the main.py
 
         d = int((-3 + math.isqrt(9 + 8*(n+1))) // 4)
+        d = d - ((1 - d) % 2)
+        assert d % 2 == 1
         return d
     
     elif code_name == "hh":
         # n = 5d^2 - 2d - 1 /2
         d = int((2 + math.sqrt(40 * n + 24)) / 10)
-        #d = d - ((1 - d) % 2)
+        d = d - ((1 - d) % 2) # In order to mamize the logical error rate we want odd distances according to the heavy hex author: https://journals.aps.org/prx/pdf/10.1103/PhysRevX.10.011022
+        assert d % 2 == 1
         return d
     elif code_name == "gross":
         return 12
     elif code_name == "color":
         d = int((math.sqrt(4*n) +1)/3)
-        #d = d - ((1 - d) % 2)
+        d = d - ((1 - d) % 2) # we look into triangular color code which has odd distance
+        assert d % 2 == 1
         return d
     elif code_name == "bacon":
         #TODO: check this

--- a/codes/utils.py
+++ b/codes/utils.py
@@ -1,7 +1,7 @@
 import math
 from .gross_code import get_gross_code
 from .color_code_stim import get_color_code
-from .bacon_shor import get_bacon_shot_code
+from .bacon_shor import get_bacon_shor_code
 from .concat_steane import get_concat_steane_code
 from .surface_code import get_surface_code
 from .hh_code import get_hh_code
@@ -31,9 +31,9 @@ def get_code(code_name: str, d: int, cycles: int):
             return get_color_code(d, rounds=cycles)
     elif code_name == "bacon":
         if cycles == None:
-            return get_bacon_shot_code(d)
+            return get_bacon_shor_code(d)
         else:
-            return get_bacon_shot_code(d, cycles)
+            return get_bacon_shor_code(d, cycles)
     elif code_name == 'steane':
         if d == 3:
             m = 1
@@ -53,35 +53,14 @@ def get_max_d(code_name: str, n: int):
 
         d = int((-3 + math.isqrt(9 + 8*(n+1))) // 4)
         return d
-        
-        #Either remove or keep for sanity checks n = 2d^2 + 3d - 1
-        #if n >= 944:
-        #    return 21
-        #elif n >= 778:
-        #    return 19
-        #elif n >= 628:
-        #    return 17
-        #elif n >= 494:
-        #    return 15
-        #elif n >= 376:
-        #    return 13
-        #elif n >= 274:
-        #    return 11
-        #elif n >= 188:
-        #    return 9
-        #elif n >= 118:
-        #   return 7
-        #elif n >= 64:
-        #    return 5
-        #elif n >= 26:
-        #    return 3 
+    
     elif code_name == "hh":
         # n = 5d^2 - 2d - 1 /2
         d = int((2 + math.sqrt(40 * n + 24)) / 10)
         #d = d - ((1 - d) % 2)
         return d
     elif code_name == "gross":
-        return math.floor(n / 2)
+        return 12
     elif code_name == "color":
         d = int((math.sqrt(4*n) +1)/3)
         #d = d - ((1 - d) % 2)

--- a/experiments.yaml
+++ b/experiments.yaml
@@ -1,12 +1,12 @@
 experiments:
-  - name: "Const_cycles"
-    num_samples: 1000
-    backends: ["custom_full"] # custom_line, custom_grid, custom_cube, custom_full
-    backends_sizes: [400]
-    codes: ["surface", "hh", "gross", "color", "steane", "bacon"]
-    error_types: ["constant"]
-    error_probabilities: [0.004] 
-    decoders: ["bposd"] # mwpm
+  #- name: "Const_cycles"
+  #  num_samples: 1000
+  #  backends: ["custom_full"] # custom_line, custom_grid, custom_cube, custom_full
+  #  backends_sizes: [400]
+  #  codes: ["surface", "hh", "gross", "color", "steane", "bacon"]
+  #  error_types: ["constant"]
+  #  error_probabilities: [0.004] 
+  #  decoders: ["bposd"] # mwpm
     #- name: "Topology_size_27.05_si_steane"
     #num_samples: 1000
     #backends: ["custom_full"] # custom_line, custom_grid, custom_cube, custom_full
@@ -16,8 +16,8 @@ experiments:
     #error_types: ["si1000"]
     #error_probabilities: [0.01, 0.005, 0.015] 
     #decoders: ["bposd"] # mwpm
-  - name: "gross_test"
-    num_samples: 10000
+  - name: "distances_check"
+    num_samples: 10
     backends: ["custom_full"] # custom_line, custom_grid, custom_cube, custom_full
     #backends_sizes: [400] #[64, 125, 216, 343, 512]
     codes: ["steane"]


### PR DESCRIPTION
Added checks for odd distances.
Surface Code, Triangular color code and heavy hex code need to be odd (either for performance reasons or because of their definition)

Bacon-Shor code takes in the number of qubits and returns the squareroot of that for the distance. That's true for the current implementation of bacon shor but.

gross code returns 12

steane code returns a distances depeding on how many qubits we are using